### PR TITLE
Change password end point

### DIFF
--- a/SchoolProject.Api/Controllers/AccountController.cs
+++ b/SchoolProject.Api/Controllers/AccountController.cs
@@ -18,6 +18,12 @@ namespace SchoolProject.Api.Controllers
             var response = await Mediator.Send(command);
             return NewResult(response);
         }
+        [HttpPut(Router.AccountRouting.ChangePassword)]
+        public async Task<IActionResult> ChangeUserPasswordAsyns([FromBody] ChangePasswordCommand command)
+        {
+            var response = await Mediator.Send(command);
+            return NewResult(response);
+        }
         [HttpGet(Router.AccountRouting.Paginate)]
         public async Task<IActionResult> GetUserPaginationAsyns([FromQuery] GetUsersPaginationQuery query)
         {

--- a/SchoolProject.Core/Features/UserIdentity/Commands/Models/ChangePasswordCommand.cs
+++ b/SchoolProject.Core/Features/UserIdentity/Commands/Models/ChangePasswordCommand.cs
@@ -1,0 +1,9 @@
+﻿namespace SchoolProject.Core.Features.UserIdentity.Commands.Models
+{
+    public class ChangePasswordCommand : IRequest<Response<string>>
+    {
+        public string Id { get; set; }
+        public string CurrentPassword { get; set; }
+        public string NewPassword { get; set; }
+    }
+}

--- a/SchoolProject.Core/Features/UserIdentity/Commands/Validators/ChangePasswordValidator.cs
+++ b/SchoolProject.Core/Features/UserIdentity/Commands/Validators/ChangePasswordValidator.cs
@@ -1,0 +1,50 @@
+﻿using FluentValidation;
+using SchoolProject.Core.Features.UserIdentity.Commands.Models;
+
+namespace SchoolProject.Core.Features.UserIdentity.Commands.Validators
+{
+    public class ChangePasswordValidator : AbstractValidator<ChangePasswordCommand>
+    {
+        #region Fields
+        private readonly IStringLocalizer<SharedResources> _localizer;
+
+        #endregion
+        public ChangePasswordValidator(IStringLocalizer<SharedResources> localizer)
+        {
+            _localizer = localizer;
+            ApplyValidataionsRules();
+            ApplyCustomValidataionsRules();
+        }
+        #region Constructors
+
+        #endregion
+        #region Handles Methods
+        public void ApplyValidataionsRules()
+        {
+
+            RuleFor(r => r.CurrentPassword)
+                .NotEmpty().WithMessage(_localizer[SharedResourcesKeys.Required])
+                .NotNull().WithMessage(_localizer[SharedResourcesKeys.NotEmpty]);
+            //.MinimumLength(8).WithMessage($"{_localizer[SharedResourcesKeys.Minimum]} 8")
+            //.Matches(@"[A-Z]").WithMessage(_localizer[SharedResourcesKeys.PasswordUppercase])
+            //.Matches(@"[a-z]").WithMessage(_localizer[SharedResourcesKeys.PasswordLowercase])
+            //.Matches(@"[0-9]").WithMessage(_localizer[SharedResourcesKeys.PasswordDigit])
+            //.Matches(@"[\@\!\#\$\%\^\&\*]").WithMessage(_localizer[SharedResourcesKeys.PasswordSpecial]);
+            RuleFor(r => r.NewPassword)
+                .NotEmpty().WithMessage(_localizer[SharedResourcesKeys.Required])
+                .NotNull().WithMessage(_localizer[SharedResourcesKeys.NotEmpty]);
+            //.MinimumLength(8).WithMessage($"{_localizer[SharedResourcesKeys.Minimum]} 8")
+            //.Matches(@"[A-Z]").WithMessage(_localizer[SharedResourcesKeys.PasswordUppercase])
+            //.Matches(@"[a-z]").WithMessage(_localizer[SharedResourcesKeys.PasswordLowercase])
+            //.Matches(@"[0-9]").WithMessage(_localizer[SharedResourcesKeys.PasswordDigit])
+            //.Matches(@"[\@\!\#\$\%\^\&\*]").WithMessage(_localizer[SharedResourcesKeys.PasswordSpecial]);
+        }
+
+        public void ApplyCustomValidataionsRules()
+        {
+
+
+        }
+        #endregion
+    }
+}

--- a/SchoolProject.Core/Resources/SharedResourcesKeys.cs
+++ b/SchoolProject.Core/Resources/SharedResourcesKeys.cs
@@ -17,10 +17,13 @@
         public const string Minimum = "Minimum";
         public const string EmailExist = "EmailExist";
         public const string UsernameTaken = "UsernameTaken";
-        public const string CreationFaild = "CreationFaild";
 
+
+        public const string CreationFaild = "CreationFaild";
+        public const string PasswordChanged = "PasswordChanged";
         public const string NoEmailorUsername = "NoEmailorUsername";
         public const string UpdatedFaild = "UpdatedFaild";
+        public const string IncorrectPassword = "IncorrectPassword";
 
         public const string PasswordUppercase = "PasswordUppercase";
         public const string PasswordLowercase = "PasswordLowercase";

--- a/SchoolProject.Data/AppMetaData/Router.cs
+++ b/SchoolProject.Data/AppMetaData/Router.cs
@@ -40,6 +40,8 @@
             public const string Paginate = Prefix + "/Paginate";
             public const string Edit = Prefix + "/Edit";
             public const string Delete = Prefix + "/Delete" + Id;
+            public const string ChangePassword = Prefix + "/ChangePassword";
+
 
         }
     }


### PR DESCRIPTION
#### PR Classification
New feature to enable users to change their passwords.

#### PR Summary
Introduced functionality for users to change their passwords via a new API endpoint.
- `AccountController.cs`: Added `ChangeUserPasswordAsync` method to handle password changes.
- `UserCommandHandler.cs`: Implemented logic to handle `ChangePasswordCommand`.
- `ChangePasswordCommand.cs`: Created `ChangePasswordCommand` class for password change data.
- `ChangePasswordValidator.cs`: Added validation rules for `ChangePasswordCommand`.
- `Router.cs`: Updated to include a new route for changing passwords.
